### PR TITLE
Fix StickyHeader clipping at high DPI

### DIFF
--- a/Assets/qss/cozy-parchment.qss
+++ b/Assets/qss/cozy-parchment.qss
@@ -196,3 +196,16 @@ QComboBox::down-arrow {
     border-top: 5px solid #8B4513;
     margin-right: 5px;
 }
+
+/* Header widget for sticky notes */
+StickyHeader {
+    padding-left: 6px;
+    padding-right: 6px;
+    max-height: 40px;
+}
+
+StickyHeader QPushButton#headerButton {
+    padding: 0px;
+    margin: 0px;
+    min-width: 0px;
+}

--- a/Assets/qss/dark.qss
+++ b/Assets/qss/dark.qss
@@ -200,3 +200,16 @@ QComboBox::down-arrow {
 QSystemTrayIcon {
     background-color: #2D2D2D;
 }
+
+/* Header widget for sticky notes */
+StickyHeader {
+    padding-left: 6px;
+    padding-right: 6px;
+    max-height: 40px;
+}
+
+StickyHeader QPushButton#headerButton {
+    padding: 0px;
+    margin: 0px;
+    min-width: 0px;
+}

--- a/Assets/qss/neon.qss
+++ b/Assets/qss/neon.qss
@@ -253,3 +253,16 @@ QTabBar::tab:hover {
     background-color: rgba(255, 0, 255, 0.3);
     border-color: #00FFFF;
 }
+
+/* Header widget for sticky notes */
+StickyHeader {
+    padding-left: 6px;
+    padding-right: 6px;
+    max-height: 40px;
+}
+
+StickyHeader QPushButton#headerButton {
+    padding: 0px;
+    margin: 0px;
+    min-width: 0px;
+}

--- a/src/aurora_notes/ui/sticky_widget.py
+++ b/src/aurora_notes/ui/sticky_widget.py
@@ -1,0 +1,35 @@
+"""Custom sticky note header widget."""
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QHBoxLayout, QPushButton, QSizePolicy, QWidget
+
+
+class StickyHeader(QWidget):
+    """Title bar with pin, minimize and close buttons."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        # Restrict header height to 40 px on all platforms
+        self.setMaximumHeight(40)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+
+        # Layout with consistent padding to avoid DPI cropping
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(6, 0, 6, 0)  # 6 px horizontal padding
+        layout.setSpacing(6)
+
+        # Pin, minimise and close buttons in that order
+        self.pin_button = QPushButton()
+        self.minimize_button = QPushButton()
+        self.close_button = QPushButton()
+
+        for btn in (self.pin_button, self.minimize_button, self.close_button):
+            btn.setObjectName("headerButton")  # For stylesheet targeting
+            btn.setCursor(Qt.PointingHandCursor)
+            layout.addWidget(btn)
+
+        # Spacer to push buttons to the right if header expands
+        layout.addStretch()
+
+        self.setLayout(layout)


### PR DESCRIPTION
## Summary
- ensure sticky header has padding and fixed height
- style StickyHeader buttons in all themes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f07ead0d48320ada37197e56591fb