### PR TITLE
Fix sticky header clipping

### DIFF
--- a/Assets/qss/cozy-parchment.qss
+++ b/Assets/qss/cozy-parchment.qss
@@ -205,7 +205,11 @@ StickyHeader {
 }
 
 StickyHeader QPushButton#headerButton {
+    /* Fixed size keeps emoji icons from scaling past the header */
     padding: 0px;
     margin: 0px;
-    min-width: 0px;
+    min-width: 32px;
+    min-height: 32px;
+    max-width: 32px;
+    max-height: 32px;
 }

--- a/Assets/qss/dark.qss
+++ b/Assets/qss/dark.qss
@@ -209,7 +209,11 @@ StickyHeader {
 }
 
 StickyHeader QPushButton#headerButton {
+    /* Fixed size keeps emoji icons from scaling past the header */
     padding: 0px;
     margin: 0px;
-    min-width: 0px;
+    min-width: 32px;
+    min-height: 32px;
+    max-width: 32px;
+    max-height: 32px;
 }

--- a/Assets/qss/neon.qss
+++ b/Assets/qss/neon.qss
@@ -262,7 +262,11 @@ StickyHeader {
 }
 
 StickyHeader QPushButton#headerButton {
+    /* Fixed size keeps emoji icons from scaling past the header */
     padding: 0px;
     margin: 0px;
-    min-width: 0px;
+    min-width: 32px;
+    min-height: 32px;
+    max-width: 32px;
+    max-height: 32px;
 }

--- a/src/aurora_notes/ui/sticky_widget.py
+++ b/src/aurora_notes/ui/sticky_widget.py
@@ -14,10 +14,13 @@ class StickyHeader(QWidget):
         self.setMaximumHeight(40)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
-        # Layout with consistent padding to avoid DPI cropping
+        # Layout with padding so icons are never clipped at high DPI
         layout = QHBoxLayout(self)
         layout.setContentsMargins(6, 0, 6, 0)  # 6 px horizontal padding
         layout.setSpacing(6)
+
+        # Spacer placed before buttons so they stay aligned right
+        layout.addStretch()
 
         # Pin, minimise and close buttons in that order
         self.pin_button = QPushButton()
@@ -28,8 +31,5 @@ class StickyHeader(QWidget):
             btn.setObjectName("headerButton")  # For stylesheet targeting
             btn.setCursor(Qt.PointingHandCursor)
             layout.addWidget(btn)
-
-        # Spacer to push buttons to the right if header expands
-        layout.addStretch()
 
         self.setLayout(layout)


### PR DESCRIPTION
## Summary
- keep header buttons right-aligned and side-by-side
- use stylesheet to fix button size across DPI scaling

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684f315ec22c8320aa59f3c59bb36c75