### PR TITLE
Fix header button clipping

### DIFF
--- a/Assets/qss/cozy-parchment.qss
+++ b/Assets/qss/cozy-parchment.qss
@@ -199,17 +199,25 @@ QComboBox::down-arrow {
 
 /* Header widget for sticky notes */
 StickyHeader {
-    padding-left: 6px;
-    padding-right: 6px;
+    /* Balanced padding so emoji icons fit at all scales */
+    padding: 2px 6px;
     max-height: 40px;
 }
 
 StickyHeader QPushButton#headerButton {
-    /* Fixed size keeps emoji icons from scaling past the header */
-    padding: 0px;
+    /* Rounded buttons with padding prevent emoji clipping */
+    padding: 6px;
     margin: 0px;
-    min-width: 32px;
-    min-height: 32px;
-    max-width: 32px;
-    max-height: 32px;
+    min-width: 36px;
+    min-height: 36px;
+    max-width: 36px;
+    max-height: 36px;
+    border: 2px solid transparent;
+    border-radius: 8px;
+}
+
+StickyHeader QPushButton#headerButton:hover {
+    /* Warm parchment hover */
+    background-color: rgba(210, 105, 30, 0.2);
+    border-color: #8B4513;
 }

--- a/Assets/qss/dark.qss
+++ b/Assets/qss/dark.qss
@@ -203,17 +203,25 @@ QSystemTrayIcon {
 
 /* Header widget for sticky notes */
 StickyHeader {
-    padding-left: 6px;
-    padding-right: 6px;
+    /* 6px horizontal and 2px vertical padding keep icons centred */
+    padding: 2px 6px;
     max-height: 40px;
 }
 
 StickyHeader QPushButton#headerButton {
-    /* Fixed size keeps emoji icons from scaling past the header */
-    padding: 0px;
+    /* Rounded buttons with padding prevent emoji clipping */
+    padding: 6px;
     margin: 0px;
-    min-width: 32px;
-    min-height: 32px;
-    max-width: 32px;
-    max-height: 32px;
+    min-width: 36px;
+    min-height: 36px;
+    max-width: 36px;
+    max-height: 36px;
+    border: 2px solid transparent;
+    border-radius: 8px;
+}
+
+StickyHeader QPushButton#headerButton:hover {
+    /* Subtle hover highlight matching toolbar buttons */
+    background-color: #3D3D3D;
+    border-color: #555555;
 }

--- a/Assets/qss/neon.qss
+++ b/Assets/qss/neon.qss
@@ -256,17 +256,26 @@ QTabBar::tab:hover {
 
 /* Header widget for sticky notes */
 StickyHeader {
-    padding-left: 6px;
-    padding-right: 6px;
+    /* 6px side padding with 2px top/bottom for DPI scaling */
+    padding: 2px 6px;
     max-height: 40px;
 }
 
 StickyHeader QPushButton#headerButton {
-    /* Fixed size keeps emoji icons from scaling past the header */
-    padding: 0px;
+    /* Rounded buttons with padding prevent emoji clipping */
+    padding: 6px;
     margin: 0px;
-    min-width: 32px;
-    min-height: 32px;
-    max-width: 32px;
-    max-height: 32px;
+    min-width: 36px;
+    min-height: 36px;
+    max-width: 36px;
+    max-height: 36px;
+    border: 2px solid transparent;
+    border-radius: 8px;
+}
+
+StickyHeader QPushButton#headerButton:hover {
+    /* Subtle neon hover */
+    background-color: rgba(255, 0, 255, 0.2);
+    border-color: #00FFFF;
+    box-shadow: 0 0 10px #00FFFF;
 }

--- a/src/aurora_notes/ui/sticky_widget.py
+++ b/src/aurora_notes/ui/sticky_widget.py
@@ -16,7 +16,9 @@ class StickyHeader(QWidget):
 
         # Layout with padding so icons are never clipped at high DPI
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(6, 0, 6, 0)  # 6 px horizontal padding
+        # Vertical margins give the buttons breathing room and keep them
+        # centred when scaled on high-DPI displays.
+        layout.setContentsMargins(6, 2, 6, 2)
         layout.setSpacing(6)
 
         # Spacer placed before buttons so they stay aligned right


### PR DESCRIPTION
## Summary
- tweak layout margins in `StickyHeader`
- style header buttons with rounded borders and hover effects
- ensure high DPI buttons are padded and visible

## Testing
- `black src/aurora_notes/ui/sticky_widget.py`
- `ruff check src/aurora_notes/ui/sticky_widget.py`
- `mypy src/aurora_notes/ui/sticky_widget.py` *(fails: "type[QSizePolicy]" has no attribute "Expanding")*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f39bbe8048320b01ee7d180ea9002